### PR TITLE
Fix escaped strings getting set in db

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,7 +43,7 @@ module.exports.wp = function(use,args,flags,cb){
 			return flags[k].map(function(flag){
 				if(flag===true)
 					return util.format("--%s",k);
-				return util.format("--%s=%s",k,escapeshell(flag));
+				return util.format('--%s="%s"',k,escapeshell(flag));
 			}).join(" ");
 		}).join(" ");
 	} else {


### PR DESCRIPTION
Currently running something like this:

``` js
wp.option.update('blogdescription', "A new tagline", function(err, data) {
    console.log("Tagline/description set.");
});
```

can result in the string `A\ new\ tagline` being set in the database.  Wrapping the values of the args in double quotes when creating the cli args fixes this.
