### PR TITLE
fix buffer size for cmd-dump call

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -12,7 +12,9 @@ var schema = function(cb){
 	exec("wp cli info"+flagIfRoot()+" --format=json",function(err,stdout,stderr){
 		var info = JSON.parse(stdout);
 		
-		exec("wp cli cmd-dump"+flagIfRoot()+"",function(err,stdout,stderr){
+		exec("wp cli cmd-dump"+flagIfRoot()+"", {
+			maxBuffer: 1024 * 1024
+		}, function(err,stdout,stderr){
 			
 			var data = JSON.parse(stdout);
 			//fs.writeFile(__dirname+"/../cache/dump.json",JSON.stringify(data,false,4),console.log);


### PR DESCRIPTION
this should fix your open issue:
https://github.com/gtg092x/node-wp-cli/issues/6

would be nice if you could merge this request or find another way to make it work with recent wp cli versions.

Thanks a lot

Thorsten